### PR TITLE
Updating scraper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["web-programming"]
 
 [dependencies]
 reqwest = "0.9.5"
-scraper = "0.9.0"
+scraper = "0.11.0"


### PR DESCRIPTION
```
error[E0506]: cannot assign to `self.input.cached_token` because it is borrowed
   --> /home/callen/.cargo/registry/src/github.com-1ecc6299db9ec823/cssparser-0.24.1/src/parser.rs:572:17
    |
547 |     pub fn next_including_whitespace_and_comments(&mut self) -> Result<&Token<'i>, BasicParseError<'i>> {
    |                                                   - let's call the lifetime of this reference `'1`
...
560 |             Some(ref cached_token)
    |                  ---------------- borrow of `self.input.cached_token` occurs here
...
572 |                 self.input.cached_token = Some(CachedToken {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `self.input.cached_token` occurs here
...
584 |         Ok(token)
    |         --------- returning this value requires that `self.input.cached_token.0` is borrowed for `'1`

error: aborting due to previous error

```

This compile error broke downstream: such as  `url-crawler`. This version bump seems to clear it up.