### PR TITLE
Starts with char literal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["web-programming"]
 
 [dependencies]
 reqwest = "0.9.5"
-scraper = "0.9.0"
+scraper = "0.11.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ impl<'a, 'b> Iterator for UrlIter<'a, 'b> {
     fn next(&mut self) -> Option<Self::Item> {
         for element in &mut self.data {
             if let Some(url) = element.value().attr("href") {
-                if ! url.starts_with("?") {
+                if ! url.starts_with('?') {
                     if let Ok(url) = self.url.join(url) {
                         return Some((element.inner_html(), url));
                     }


### PR DESCRIPTION
`starts_with` can take a char literal instead of a single character string slice.